### PR TITLE
added support for UP5K on upduino

### DIFF
--- a/ice40up5k-upduino.pcf
+++ b/ice40up5k-upduino.pcf
@@ -1,0 +1,16 @@
+# using the internal 48MHz hifreq osc
+#set_io clk       35
+set_io flash_clk 15
+set_io flash_csn 16
+set_io flash_io0 17
+set_io flash_io1 14
+set_io leds[0]   38
+set_io leds[1]   42
+set_io leds[2]   36
+set_io leds[3]   43
+set_io leds[4]   34
+set_io leds[5]   37
+set_io leds[6]   31
+set_io leds[7]   32
+set_io uart_rx   12
+set_io uart_tx   21

--- a/top.sv
+++ b/top.sv
@@ -6,7 +6,9 @@
 `include "uart.sv"
 
 module top (
+`ifndef up5k
     input clk,
+`endif
 
     /* serial flash */
     output logic flash_clk,
@@ -28,6 +30,15 @@ module top (
     logic flash_io1_en;
     logic flash_io1_in;
     logic flash_io1_out;
+
+`ifdef up5k
+    wire clk;
+    SB_HFOSC inthosc (
+        .CLKHFPU(1'b1),
+        .CLKHFEN(1'b1),
+        .CLKHF(clk)
+    );
+`endif
 
     SB_IO #(
         .PIN_TYPE(6'b1010_01)

--- a/top.tcl
+++ b/top.tcl
@@ -1,0 +1,12 @@
+yosys -import
+read_verilog -D$::env(IC) -noautowire -sv top.sv
+puts "device is $::env(IC)" ; 
+
+#yosys proc
+procs
+# the above are the same, see: http://www.clifford.at/yosys/cmd_tcl.html
+
+opt -full
+alumacc
+share -aggressive
+synth_ice40 -abc2 -top top -blif top.blif

--- a/top.ys
+++ b/top.ys
@@ -1,6 +1,0 @@
-read_verilog -noautowire -sv top.sv
-proc
-opt -full
-alumacc
-share -aggressive
-synth_ice40 -abc2 -top top -blif top.blif


### PR DESCRIPTION
hi, i have got an UPDuino board (fixed with PLL caps).
so i've ported your icicle design to this FPGA with a new constraint file and a small `ifdef on the top.sv to enable the internal oscillator.

to make verilog "compilation" parametric, i had to move from yosys internal script to TCL script (conceptually identical BUT can read environment vars).

i took more time dealing with this issue, then in the main patch itself.
the upduino firmware is a new target of the Makefile: make upduino.

this is an enhancement, the 8k part is still supported with the usual make (all) command.

bye
